### PR TITLE
Add to api url so that all the needed data is present in returned object

### DIFF
--- a/lib/components/Main.js
+++ b/lib/components/Main.js
@@ -5,7 +5,7 @@ export default class Main extends Component {
   render() {
     return (
       <div>
-        <Controls source='http://api.wunderground.com/api/e94636a61d05b634/forecast/q/CO/' />
+        <Controls source='http://api.wunderground.com/api/e94636a61d05b634/forecast/hourly/forecast10day/conditions/geolookup/q/CO/' />
       </div>
     )
   }


### PR DESCRIPTION
I originally pushed this to master on accident, so there may not be much to review. But I changed the url for the api to include all the relevant sections, so now we have one object with everything we need (and probably a lot we don't).

In the URL, to add sections, you can chain things together after the api key. So it looks something like:
url: som3ApiKey/conditions/forecast/forecast10day/conditions/geolocate/otherthings